### PR TITLE
Fix recursive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ information on how to leverage this.
 
 
 # Maintainer(s)
-* Philip Bergman <philip@zicht.nl>
+* Jochem Klaver <jochem@zicht.nl>
 

--- a/env/z.yml
+++ b/env/z.yml
@@ -90,7 +90,7 @@ tasks:
             target_env: ?
             file: ?
         do: |
-            scp -P $(envs[target_env].ssh_port) $(recursive ? "-R") $(envs[target_env].ssh):$(envs[target_env].root)$(file) ./$(file)
+            scp -P $(envs[target_env].ssh_port) $(recursive ? "-r") $(envs[target_env].ssh):$(envs[target_env].root)$(file) ./$(file)
 
     env.put:
         help: |
@@ -101,7 +101,7 @@ tasks:
             target_env: ?
             file: ?
         do:
-            - scp -P $(envs[target_env].ssh_port) $(recursive ? "-R") ./$(file) $(envs[target_env].ssh):$(envs[target_env].root)$(file)
+            - scp -P $(envs[target_env].ssh_port) $(recursive ? "-r") ./$(file) $(envs[target_env].ssh):$(envs[target_env].root)$(file)
 
     env.port-forward:
         help: |


### PR DESCRIPTION
While executing the command `env.put` or `env.get` an error occured: `unknown option --R`.
It seems that the recursive flag needs to be lowercase.